### PR TITLE
Short pipeline remaining time fix

### DIFF
--- a/WriteProgressPlus/Components/NoThrottleDynamicParameter.cs
+++ b/WriteProgressPlus/Components/NoThrottleDynamicParameter.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Management.Automation;
+using System.Text;
+
+namespace WriteProgressPlus.Components;
+public class NoThrottleDynamicParameter
+{
+    [Parameter]
+    public SwitchParameter NoThrottle { get; set; }
+}

--- a/WriteProgressPlus/Components/PowershellVersionDifferences.cs
+++ b/WriteProgressPlus/Components/PowershellVersionDifferences.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Management.Automation;
+using System.Text;
+
+namespace WriteProgressPlus.Components;
+internal static class PowershellVersionDifferences
+{
+    /// <summary>
+    /// Since Powershell 6 ConsoleHost will automatically throttle updates to the progress bar.
+    /// <para/>
+    /// As per <see href="https://github.com/PowerShell/PowerShell/pull/2822">PR #2822</see>
+    /// the host will ignore updates until 200ms have passed since last update
+    /// <para/>
+    /// The PR was part of the <see href="https://github.com/PowerShell/PowerShell/releases/tag/v6.0.0-alpha.18">v6.0.0-alpha.18</see> release,
+    /// so we can test if the host has throttling built-in by checking if the major version is greater than 6
+    /// (I assume, that no-one would be using pre-alpha18 Powershell 6 anymore).
+    /// <para/>
+    /// While it won't really be a problem, if the cmdlet does an additional throttling,
+    /// for performance and simplicity reasons it's better to skip it, where applicable.
+    /// </summary>
+    /// <param name="runtime"></param>
+    /// <returns>If host has built-in throttling - <see langword="true"/>. Otherwise - <see langword="false"/></returns>
+    public static bool IsThrottlingBuiltIn(ICommandRuntime runtime)
+    {
+        var runtimeVersion = runtime.Host.Version;
+        // The throttling applies only to ConsoleHost, as far as I am aware, so better make sure it matches.
+        var runtimeName = runtime.Host.Name;
+        return runtimeName is "ConsoleHost" && runtimeVersion.Major >= 6;
+    }
+}

--- a/WriteProgressPlus/Components/ProgressBaseCommand.cs
+++ b/WriteProgressPlus/Components/ProgressBaseCommand.cs
@@ -32,7 +32,7 @@ public class ProgressBaseCommand : PSCmdlet
                 // Do not write the comlete bar - due to pwsh7 throttling the complete update of bar
                 // will make the new bar not display
                 // From powershell point of view the bar never went away, just changed activity, etc...
-                RemoveProgressInner(current.ID, false);
+                RemoveProgressState(current.ID, false);
                 return AddNewProgressInner(current);
             }
         }
@@ -54,8 +54,8 @@ public class ProgressBaseCommand : PSCmdlet
     /// <para/>
     /// If state is removed, its bar will be updated once with RecordType set to complete to clear it.
     /// </summary>
-    /// <inheritdoc cref="RemoveProgressInner(int, bool)"/>
-    public static bool RemoveProgressInner(int id) => RemoveProgressInner(id, writeCompleted: true);
+    /// <inheritdoc cref="RemoveProgressState(int, bool)"/>
+    public static bool RemoveProgressState(int id) => RemoveProgressState(id, writeCompleted: true);
 
     /// <summary>
     /// Removes progress bar state associated with the given id. Does nothing if id is not associated with anything.
@@ -64,7 +64,7 @@ public class ProgressBaseCommand : PSCmdlet
     /// </summary>
     /// <param name="id">ID of ProgressState</param>
     /// <returns></returns>
-    private static bool RemoveProgressInner(int id, bool writeCompleted)
+    private static bool RemoveProgressState(int id, bool writeCompleted)
     {
         if (!ProgressDict.TryGetValue(id, out ProgressState? progressInner))
         {
@@ -90,12 +90,12 @@ public class ProgressBaseCommand : PSCmdlet
     /// <summary>
     /// Removes all progress bar states
     /// </summary>
-    public void ClearProgressInners()
+    public void ClearProgressStates()
     {
         var keys = ProgressDict.Keys.ToArray();
         foreach (int id in keys)
         {
-            RemoveProgressInner(id);
+            RemoveProgressState(id);
         }
     }
 }

--- a/WriteProgressPlus/Components/ProgressBaseCommand.cs
+++ b/WriteProgressPlus/Components/ProgressBaseCommand.cs
@@ -52,12 +52,18 @@ public class ProgressBaseCommand : PSCmdlet
     /// <summary>
     /// Removes progress bar state associated with the given id. Does nothing if id is not associated with anything.
     /// <para/>
-    /// If state is removed, its bar will be updated once with RecordType set to complete.
+    /// If state is removed, its bar will be updated once with RecordType set to complete to clear it.
+    /// </summary>
+    /// <inheritdoc cref="RemoveProgressInner(int, bool)"/>
+    public static bool RemoveProgressInner(int id) => RemoveProgressInner(id, writeCompleted: true);
+
+    /// <summary>
+    /// Removes progress bar state associated with the given id. Does nothing if id is not associated with anything.
+    /// <para/>
+    /// If state is removed and <paramref name="writeCompleted"/> is <see langword="true"/>, its bar will be updated once with RecordType set to complete to clear it.
     /// </summary>
     /// <param name="id">ID of ProgressState</param>
     /// <returns></returns>
-    public static bool RemoveProgressInner(int id) => RemoveProgressInner(id, writeCompleted: true);
-
     private static bool RemoveProgressInner(int id, bool writeCompleted)
     {
         if (!ProgressDict.TryGetValue(id, out ProgressState? progressInner))
@@ -71,7 +77,7 @@ public class ProgressBaseCommand : PSCmdlet
             // This ensures that the bar will be removed
             progressInner.AssociatedRecord.RecordType = ProgressRecordType.Completed;
             progressInner.AssociatedRecord.PercentComplete = 100;
-            progressInner.WriteProgress();
+            progressInner.WriteProgress(force: true);
             // However, if the state is being removed, because a new bar from different command is requested
             // We should not complete it - the bar should be reused
             // Thus we skip this section altogether if writeCompleted is false

--- a/WriteProgressPlus/Components/ProgressBaseCommand.cs
+++ b/WriteProgressPlus/Components/ProgressBaseCommand.cs
@@ -18,7 +18,7 @@ public class ProgressBaseCommand : PSCmdlet
     /// </summary>
     /// <param name="current"></param>
     /// <returns></returns>
-    public static ProgressState GetProgressState(WriteProgressPlusCommand current)
+    internal static ProgressState GetProgressState(WriteProgressPlusCommand current)
     {
         if (ProgressDict.TryGetValue(current.ID, out ProgressState? existingProgressState))
         {

--- a/WriteProgressPlus/Components/ProgressState.cs
+++ b/WriteProgressPlus/Components/ProgressState.cs
@@ -5,7 +5,7 @@ using static WriteProgressPlus.Components.PowershellVersionDifferences;
 
 namespace WriteProgressPlus.Components;
 
-public sealed class ProgressState
+internal sealed class ProgressState
 {
     private readonly TimeSpan Negative = TimeSpan.FromSeconds(-1);
 

--- a/WriteProgressPlus/Components/ProgressState.cs
+++ b/WriteProgressPlus/Components/ProgressState.cs
@@ -1,6 +1,7 @@
 ﻿using System.Management.Automation;
 using System.Text;
 using static System.Globalization.CultureInfo;
+using static WriteProgressPlus.Components.PowershellVersionDifferences;
 
 namespace WriteProgressPlus.Components;
 
@@ -88,8 +89,15 @@ public sealed class ProgressState
         };
     }
 
-    /// <inheritdoc cref="TimeKeeper.ShouldDisplay"/>
-    public bool ShouldDisplay() => Keeper.ShouldDisplay();
+    public bool ShouldUpdate()
+    {
+        if (IsThrottlingBuiltIn(CmdRuntime))
+        {
+            // The updates may be very frequent, but the built-in throttling will handle it.
+            return true;
+        }
+        return Keeper.UpdatedPermitted();
+    }
 
     /// <summary>
     /// Calculate percent done using donor's TotalCount and <see cref="ActualCurrentIteration"/>.
@@ -237,7 +245,7 @@ public sealed class ProgressState
     /// </summary>
     public void WriteProgress(bool force = false)
     {
-        if (force || ShouldDisplay())
+        if (force || ShouldUpdate())
         {
             CmdRuntime?.WriteProgress(AssociatedRecord);
         }

--- a/WriteProgressPlus/Components/ProgressState.cs
+++ b/WriteProgressPlus/Components/ProgressState.cs
@@ -232,14 +232,14 @@ public sealed class ProgressState
     }
 
     /// <summary>
-    /// Makes ICommandRuntime associated with the ProgressState call its WriteProgress
+    /// Makes ICommandRuntime associated with the ProgressState call its WriteProgress.
+    /// Can be skipped by throttling, unless <paramref name="force"/> is <see langword="true"/>
     /// </summary>
-    public void WriteProgress()
+    public void WriteProgress(bool force = false)
     {
-        if (!ShouldDisplay())
+        if (force || ShouldDisplay())
         {
-            return;
+            CmdRuntime?.WriteProgress(AssociatedRecord);
         }
-        CmdRuntime?.WriteProgress(AssociatedRecord);
     }
 }

--- a/WriteProgressPlus/Components/ProgressState.cs
+++ b/WriteProgressPlus/Components/ProgressState.cs
@@ -15,11 +15,17 @@ internal sealed class ProgressState
     {
         Id = donor.ID;
         ParentId = donor.ParentID < ProgressBaseCommand.Offset ? -1 : donor.ParentID;
-        Keeper = new TimeKeeper();
-        AssociatedRecord = new(donor.ID, Placeholder, Placeholder);
+
+        // Let the calculation length about 1/20 of the total length, still subject to minimum, maximum and calculation lengths in  Buffer
+        int timeCalculationLength = donor.TotalCount / 20;
+        Keeper = new TimeKeeper(timeCalculationLength);
+
+        AssociatedRecord = new ProgressRecord(donor.ID, Placeholder, Placeholder);
+
         // try to reuse parentRuntime
         ICommandRuntime? parentRuntime = ParentId > 0 ? ProgressBaseCommand.ProgressDict[ParentId].CmdRuntime : null;
         CmdRuntime = parentRuntime ?? donor.CommandRuntime;
+
         HistoryId = donor.HistoryId;
     }
 

--- a/WriteProgressPlus/Components/TimeBuffer.cs
+++ b/WriteProgressPlus/Components/TimeBuffer.cs
@@ -6,6 +6,16 @@
 /// </summary>
 class TimeBuffer
 {
+    /// <summary>
+    /// Upper limit to avoid having too large buffers.
+    /// </summary>
+    public static readonly int MaxCalculationLength = 5000;
+
+    /// <summary>
+    /// Lower limit to avoid having too large buffers.
+    /// </summary>
+    public static readonly int MinCalculationLength = 50;
+
     private readonly TimeSpan[] timeSpans;
 
     private DateTime LastDataPoint = DateTime.MinValue;
@@ -24,7 +34,7 @@ class TimeBuffer
 
     public TimeBuffer(int calculationLength)
     {
-        MaxLength = calculationLength > 0 ? calculationLength : 1;
+        MaxLength = Math.Min(Math.Max(MinCalculationLength, calculationLength), MaxCalculationLength);
         timeSpans = new TimeSpan[MaxLength];
     }
     /// <summary>

--- a/WriteProgressPlus/Components/TimeKeeper.cs
+++ b/WriteProgressPlus/Components/TimeKeeper.cs
@@ -18,25 +18,18 @@ internal class TimeKeeper
     /// </remarks>
     public static readonly long UpdatePeriodTicks = 2_000_000; // tick is 100ns => 200ms
 
-    /// <summary>
-    /// How many elements should be considered when calculating ETA
-    /// </summary>
-    public const int CalculationLength = 50;
-
     public long LastDisplayTimeTicks { get; set; }
 
     private TimeBuffer Buffer { get; }
 
-    private TimeKeeper(int calculationLength)
+    public TimeKeeper(int calculationLength)
     {
-        Buffer = new(calculationLength);
+        Buffer = new TimeBuffer(calculationLength);
         // Make sure the first iteration can be displayed
         // .UtcNow is about 3 times faster than .Now
         LastDisplayTimeTicks = DateTime.UtcNow.Ticks - UpdatePeriodTicks * 5;
     }
 
-    public TimeKeeper() : this(CalculationLength)
-    { }
 
     /// <inheritdoc cref="TimeBuffer.AddTime()"/>
     public void AddTime() => Buffer.AddTime();

--- a/WriteProgressPlus/Components/TimeKeeper.cs
+++ b/WriteProgressPlus/Components/TimeKeeper.cs
@@ -6,9 +6,15 @@
 internal class TimeKeeper
 {
     /// <summary>
-    /// Minimum time between updates of progress bar. 
+    /// Minimum time between updates of progress bar.
+    /// <para/>
+    /// Set to the same values as in <see href="https://github.com/PowerShell/PowerShell/pull/2822">PR #2822</see> - 200ms
     /// </summary>
-    public static readonly TimeSpan UpdatePeriod = TimeSpan.FromMilliseconds(100);
+    /// <remarks>
+    /// More information can be found at
+    /// <seealso cref="PowershellVersionDifferences.IsThrottlingBuiltIn"/>.
+    /// </remarks>
+    public static readonly TimeSpan UpdatePeriod = TimeSpan.FromMilliseconds(200);
 
     /// <summary>
     /// How many elements should be considered when calculating ETA
@@ -41,11 +47,9 @@ internal class TimeKeeper
     /// <summary>
     /// Ensure that the progress bar won't be updated too often, which reduces performance.
     /// Updates that come too fast should be ignored.
-    /// <para/>
-    /// Powershell 7 onwards has this behavior built in.
     /// </summary>
     /// <returns></returns>
-    public bool ShouldDisplay()
+    public bool UpdatedPermitted()
     {
         TimeSpan timePassed = DateTime.Now - LastDisplayed;
         if (timePassed <= UpdatePeriod)

--- a/WriteProgressPlus/ResetProgressPlusCommand.cs
+++ b/WriteProgressPlus/ResetProgressPlusCommand.cs
@@ -21,7 +21,7 @@ public sealed class ResetProgressPlusCommand : ProgressBaseCommand
         if (All.IsPresent)
         {
             int count = ProgressDict.Count;
-            ClearProgressInners();
+            ClearProgressStates();
             WriteVerbose(Invariant($"Removed all progress bars - {count}"));
         }
     }
@@ -32,7 +32,7 @@ public sealed class ResetProgressPlusCommand : ProgressBaseCommand
         {
             foreach (int i in ID)
             {
-                if (RemoveProgressInner(i + Offset))
+                if (RemoveProgressState(i + Offset))
                     WriteVerbose(Invariant($"Removed progress bar - {i}"));
             }
         }

--- a/WriteProgressPlus/WriteProgressPlus.csproj
+++ b/WriteProgressPlus/WriteProgressPlus.csproj
@@ -8,7 +8,7 @@
 		<RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
 		<OutputType>Library</OutputType>
 		<Authors>Maciej Krosta</Authors>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 		<Title>WriteProgressPlus</Title>
 		<Description>Wrapper around WriteProgress, which automates its functionalities and allows simpler control.</Description>

--- a/WriteProgressPlus/WriteProgressPlusCommand.cs
+++ b/WriteProgressPlus/WriteProgressPlusCommand.cs
@@ -110,7 +110,7 @@ public sealed class WriteProgressPlusCommand : ProgressBaseCommand
         Formatter.Update(DisplayScript, DisplayProperties, DisplayPropertiesSeparator);
         try
         {
-            BarWorker = GetProgressInner(this);
+            BarWorker = GetProgressState(this);
         }
         catch (ArgumentException argumentException)
         {

--- a/WriteProgressPlus/WriteProgressPlusCommand.cs
+++ b/WriteProgressPlus/WriteProgressPlusCommand.cs
@@ -151,7 +151,7 @@ public sealed class WriteProgressPlusCommand : ProgressBaseCommand
         // In pipeline mode, we want to complete the bar and remove it at the end
         if (PipelineMode)
         {
-            RemoveProgressInner(ID);
+            RemoveProgressState(ID);
         }
     }
 


### PR DESCRIPTION
Caused by issue #4 

- Added option to force WriteProgress even if it would be too soon.
   - Used when removing status, as the Cleared message must be delivered for host to remove the bar.
- On ConsoleHosts for Powershell 6 and above, throttling is disabled altogether, as those hosts provide their own, faster throttling mechanism.
- Improved performance of throttling mechanism by using UtcNow (instead of Now) for DateTime, and calculating on Ticks
- Added a dynamic parameter on older hosts to allow the user to disable throttling.